### PR TITLE
Use SwitchListTiles instead of ListTiles with a trailing Switch

### DIFF
--- a/lib/ui/switches/custom_theme.dart
+++ b/lib/ui/switches/custom_theme.dart
@@ -5,13 +5,13 @@ import '../../persist_theme.dart';
 
 class CustomThemeSwitch extends StatelessWidget {
   const CustomThemeSwitch({
-    this.leading,
+    this.secondary,
     this.subtitle,
     this.title = const Text("Custom Theme"),
     this.showOnlyLightMode = true,
   });
 
-  final Widget leading, subtitle, title;
+  final Widget secondary, subtitle, title;
   final bool showOnlyLightMode;
 
   @override
@@ -19,14 +19,12 @@ class CustomThemeSwitch extends StatelessWidget {
     return new Consumer<ThemeModel>(
         builder: (context, model, child) => Container(
               child: !showOnlyLightMode || !model.darkMode && showOnlyLightMode
-                  ? ListTile(
-                      leading: leading,
+                  ? SwitchListTile.adaptive(
+                      secondary: secondary,
                       subtitle: subtitle,
                       title: title,
-                      trailing: Switch.adaptive(
-                        value: model.customTheme,
-                        onChanged: model.changeCustomTheme,
-                      ),
+                      value: model.customTheme,
+                      onChanged: model.changeCustomTheme,
                     )
                   : null,
             ));

--- a/lib/ui/switches/dark_mode.dart
+++ b/lib/ui/switches/dark_mode.dart
@@ -5,25 +5,23 @@ import '../../persist_theme.dart';
 
 class DarkModeSwitch extends StatelessWidget {
   const DarkModeSwitch({
-    this.leading,
+    this.secondary,
     this.subtitle,
     this.title = const Text("Dark Mode"),
   });
 
-  final Widget leading, subtitle, title;
+  final Widget secondary, subtitle, title;
 
   @override
   Widget build(BuildContext context) {
     return new Consumer<ThemeModel>(
         builder: (context, model, child) => Container(
-              child: ListTile(
-                leading: leading,
+              child: SwitchListTile.adaptive(
+                secondary: secondary,
                 subtitle: subtitle,
                 title: title,
-                trailing: Switch.adaptive(
-                  value: model.darkMode,
-                  onChanged: model.changeDarkMode,
-                ),
+                value: model.darkMode,
+                onChanged: model.changeDarkMode,
               ),
             ));
   }

--- a/lib/ui/switches/true_black.dart
+++ b/lib/ui/switches/true_black.dart
@@ -5,13 +5,13 @@ import '../../persist_theme.dart';
 
 class TrueBlackSwitch extends StatelessWidget {
   const TrueBlackSwitch({
-    this.leading,
+    this.secondary,
     this.subtitle,
     this.title = const Text("True Black"),
     this.showOnlyDarkMode = true,
   });
 
-  final Widget leading, subtitle, title;
+  final Widget secondary, subtitle, title;
   final bool showOnlyDarkMode;
 
   @override
@@ -19,14 +19,12 @@ class TrueBlackSwitch extends StatelessWidget {
     return new Consumer<ThemeModel>(
         builder: (context, model, child) => Container(
               child: !showOnlyDarkMode || model.darkMode && showOnlyDarkMode
-                  ? ListTile(
-                      leading: leading,
+                  ? SwitchListTile.adaptive(
+                      secondary: secondary,
                       subtitle: subtitle,
                       title: title,
-                      trailing: Switch.adaptive(
-                        value: model.trueBlack,
-                        onChanged: model.changeTrueBlack,
-                      ),
+                      value: model.trueBlack,
+                      onChanged: model.changeTrueBlack,
                     )
                   : null,
             ));


### PR DESCRIPTION
With the use of `SwitchListTile` the entire ListTile is interactive, and tapping anywhere on the Tile will trigger the switch. Note that I've renamed the `leading` parameter to `secondary` to be consistent with `SwitchListTile`, making this a breaking change. Maybe we should just keep `leading`? `secondary` is always placed in the `ListTile.leading` spot anyways, so it would probably not confuse users.