### PR TITLE
use `shrinkWrap: true` for `MaterialColorPicker`

### DIFF
--- a/lib/ui/pickers/picker.dart
+++ b/lib/ui/pickers/picker.dart
@@ -26,6 +26,7 @@ class _CustomColorPickerState extends State<CustomColorPicker> {
   @override
   Widget build(BuildContext context) {
     return MaterialColorPicker(
+      shrinkWrap: true,
       selectedColor: main,
       onMainColorChange: (ColorSwatch color) {
         if (mounted)


### PR DESCRIPTION
This is actually a regression from the flutter_material_color_picker package v1.0.4 (https://github.com/Pyozer/flutter_material_color_picker/commit/e6e638b7cef89d6c2fe62adaa49028cc5d898a14). To be able to display the color picker in a dialog inside a `SingleChildScrollView`, `shrinkWrap` must be true.