### PR TITLE
[example] fix FAB background color

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -80,7 +80,7 @@ class HomeScreen extends StatelessWidget {
               ],
       ),
       floatingActionButton: FloatingActionButton(
-        backgroundColor: _theme.accentColor,
+        backgroundColor: _theme.theme.accentColor,
         child: Icon(Icons.add),
         onPressed: () {},
       ),


### PR DESCRIPTION
As far as I can thell, `ThemeModel.accentColor` should only be used in the `ThemeModel.theme` getter for the `custom` theme. Using it directly leads to bugs. `ThemeModel.accentColor` should probably be private.