### PR TITLE
Use the ChangeNotifierProvider.value constructor

### DIFF
--- a/lib/data/models/theme_provider.dart
+++ b/lib/data/models/theme_provider.dart
@@ -16,8 +16,8 @@ class ThemeProvider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider<ThemeModel>(
-      create: (_) => model,
+    return ChangeNotifierProvider.value(
+      value: model,
       child: child,
     );
   }


### PR DESCRIPTION
According to the provider documentation:

> If you already have an object instance and want to expose it, you should use the .value constructor of a provider.

> Failing to do so may call the dispose method of your object when it is still in use.

> DO use ChangeNotifierProvider.value to provide an existing ChangeNotifier.

```
MyChangeNotifier variable;

ChangeNotifierProvider.value(
  value: variable,
  child: ...
)
```
> DON'T reuse an existing ChangeNotifier using the default constructor
```
MyChangeNotifier variable;

ChangeNotifierProvider(
  create: (_) => variable,
  child: ...
)
```